### PR TITLE
fix: image URL generated for CSS background is no more generated with wrong trailing slash placement

### DIFF
--- a/class-elementor.php
+++ b/class-elementor.php
@@ -193,8 +193,8 @@ class Elementor extends Compatibility {
           $baseurl = preg_replace('/https?:\/\//', '', $upload_data['baseurl']);
           $root_dir = trim(ud_get_stateless_media()->get('sm.root_dir'), '/ '); // Remove any forward slash and empty space.
           $root_dir = apply_filters("wp_stateless_handle_root_dir", $root_dir);
-          $root_dir = !empty($root_dir) ? $root_dir . '/' : '';
-          $image_host = ud_get_stateless_media()->get_gs_host() . $root_dir;
+          $root_dir = !empty($root_dir) ? $root_dir : '';
+          $image_host = ud_get_stateless_media()->get_gs_host() . '/' . $root_dir;
           $file_ext = ud_get_stateless_media()->replaceable_file_types();
 
           preg_match_all('/(https?:\/\/' . str_replace('/', '\/', $baseurl) . ')\/(.+?)(' . $file_ext . ')/i', $content, $matches);


### PR DESCRIPTION
See https://github.com/udx/wp-stateless/issues/769#issuecomment-2399773540 

CSS file was previously generated with a wrong placement of trailing slash, as `background-image: url("https://storage.googleapis.com/mybucket2024/10//4b509ea7-my-image.jpg");` , instead of `background-image: url("https://storage.googleapis.com/mybucket/2024/10/4b509ea7-my-image.jpg");`